### PR TITLE
[Enhancement]: Menu focus fix and filter itens.

### DIFF
--- a/armacao.json
+++ b/armacao.json
@@ -1,7 +1,7 @@
 [
   {
     "index": 9990,
-    "name": "Rayban",
+    "name": "Item 2",
     "image": "https://a3.vnda.com.br/safira/2017/06/01/1783696-oculos-de-grau-feminino-dolce-gabbana-dg-3258-501-4286.jpg?1496348036",
     "expanded": false,
     "descricao": "Oculos de sol ray ban justin rb4165l 622/55 55 preto fosco lente azul espelhada",
@@ -10,7 +10,7 @@
   },
   {
     "index": 9990,
-    "name": "Rayban",
+    "name": "Item 3",
     "image": "https://a3.vnda.com.br/safira/2017/06/01/1783696-oculos-de-grau-feminino-dolce-gabbana-dg-3258-501-4286.jpg?1496348036",
     "expanded": false,
     "descricao": "Oculos de sol ray ban justin rb4165l 622/55 55 preto fosco lente azul espelhada",
@@ -19,7 +19,7 @@
   },
   {
     "index": 9990,
-    "name": "Rayban",
+    "name": "Item 5",
     "image": "https://a3.vnda.com.br/safira/2017/06/01/1783696-oculos-de-grau-feminino-dolce-gabbana-dg-3258-501-4286.jpg?1496348036",
     "expanded": false,
     "descricao": "Oculos de sol ray ban justin rb4165l 622/55 55 preto fosco lente azul espelhada",
@@ -28,7 +28,7 @@
   },
   {
     "index": 9990,
-    "name": "Rayban",
+    "name": "Item 5",
     "image": "https://a3.vnda.com.br/safira/2017/06/01/1783696-oculos-de-grau-feminino-dolce-gabbana-dg-3258-501-4286.jpg?1496348036",
     "expanded": false,
     "descricao": "Oculos de sol ray ban justin rb4165l 622/55 55 preto fosco lente azul espelhada",

--- a/bower.json
+++ b/bower.json
@@ -50,7 +50,12 @@
     "webcomponentsjs": "^1.0.0",
     "paper-input": "^2.0.5",
     "paper-item": "^2.0.0",
-    "iron-collapse": "^2.0.0"
+    "iron-collapse": "^2.0.0",
+    "paper-styles": "^2.0.0",
+    "iron-validatable-behavior": "^2.0.0",
+    "iron-resizable-behavior": "2.0-preview",
+    "iron-form-element-behavior": "^2.0.0",
+    "iron-input": "^2.0.0"
   },
   "devDependencies": {
     "web-component-tester": "Polymer/web-component-tester#^6.0.0"

--- a/src/pages/dashboard/Dashboard.component.html
+++ b/src/pages/dashboard/Dashboard.component.html
@@ -35,7 +35,7 @@
 <link rel="import" href="../../../bower_components/paper-toggle-button/paper-toggle-button.html">
 
 <!--
-<link rel="import" href="../../../bower_components/bwt-datatable/bwt-datatable.html">
+  <link rel="import" href="../../../bower_components/bwt-datatable/bwt-datatable.html">
 -->
 
 <link rel="import" href="../../../bower_components/paper-radio-group/paper-radio-group.html">
@@ -64,12 +64,12 @@
 <link rel="import" href="../lentes/Lentes.component.html">
 <link rel="import" href="../vendas/Vendas.component.html">
 
-
 <link rel="import" href="Dashboard.style.html">
 
 <dom-module id="dashboard-page">
   <template>
     <style include="dashboard-style"></style>
+
     <app-header condenses reveals effects="waterfall">
       <app-toolbar>
         <paper-icon-button icon="menu" id="buttonMenu"></paper-icon-button>
@@ -77,122 +77,204 @@
           <img src="http://beta.spartandesign.com.br/b15/wp-content/uploads/2017/12/Logo_b15_home_footer.png" alt="B15" width="50" class="b15">
         </div>
       </app-toolbar>
-
     </app-header>
 
-    <app-drawer id="menuDrawer" align="start" swipe-open >
+    <app-drawer id="menuDrawer" align="start" swipe-open>
       <div style="height: 100%; overflow: auto;">
         <div class="head">
-          <iron-image class="avatar" sizing="contain" src="https://s3.amazonaws.com/uifaces/faces/twitter/enda/73.jpg"></iron-image>
-          <div class="contact-info">
+          <iron-image 
+             class="avatar"
+             sizing="contain"
+             src="https://s3.amazonaws.com/uifaces/faces/twitter/enda/73.jpg">
+          </iron-image>
 
+          <div class="contact-info">
             <div class="name">Orlando Bueno</div>
             <div class="email">Diniz Franchising</div>
           </div>
         </div>
 
-
-        <iron-selector id="menu" selected="[[page]]" attr-for-selected="name" class="drawer-list" role="navigation">
-
+        <iron-selector id="menu" class="drawer-list" selected="[[page]]" attr-for-selected="name" class="drawer-list" role="navigation">
           <div class="flex-horizontal">
+            <paper-item tabindex="-1">
+              <a href="[[dashboardPath]]chat" class="menu" tabindex="-1">
+                <iron-icon icon="question-answer" slot="item-icon" class="geek-blue"></iron-icon>
+                <div main-code class="bs-label bg-red">53</div>
+              </a>
+            </paper-item>
 
-            <paper-item><a href="[[dashboardPath]]chat" class="menu"><iron-icon icon="question-answer" slot="item-icon" class="geek-blue"></iron-icon><div main-code class="bs-label bg-red">53</div></a></paper-item>
+            <paper-item tabindex="-1">
+              <a href="[[dashboardPath]]timeline" class="menu" tabindex="-1">
+                <iron-icon icon="thumb-up" slot="item-icon"></iron-icon>
+                <div main-code class="bs-label bg-transparent">22</div>
+              </a>
+            </paper-item>
 
-            <paper-item><a href="[[dashboardPath]]timeline" class="menu"><iron-icon icon="thumb-up" slot="item-icon"></iron-icon> <div main-code class="bs-label bg-transparent">22</div></a></paper-item>
-
-            <paper-item><a href="[[dashboardPath]]timeline" class="menu"><iron-icon icon="social:notifications-active" slot="item-icon"></iron-icon> <div main-code class="bs-label bg-transparent">22</div></a></paper-item>
-
-
+            <paper-item tabindex="-1">
+              <a href="[[dashboardPath]]timeline" class="menu" tabindex="-1">
+                <iron-icon icon="social:notifications-active" slot="item-icon"></iron-icon> 
+                <div main-code class="bs-label bg-transparent">22</div>
+              </a>
+            </paper-item>
           </div>
+
           <hr class="separated">
 
-          <paper-menu><paper-input label="Buscar" class="card" no-label-float  >
-            <iron-icon icon="search" slot="prefix"></iron-icon>
-          </paper-input></paper-menu>
-<!--
-            <hr class="separated">
+          <paper-menu>
+            <paper-input label="Buscar" class="card" no-label-float>
+              <iron-icon icon="search" slot="prefix"></iron-icon>
+            </paper-input>
+          </paper-menu>
 
+          <hr class="separated">
 
+          <p style="padding-left: 1em; margin-bottom: 0;"><small>Menu</small></p>
 
-            <paper-item><a href="[[dashboardPath]]chat" class="menu"><iron-icon icon="question-answer" slot="item-icon" class="geek-blue"></iron-icon> Chat <div main-code class="bs-label bg-red">53</div></a></paper-item>
+          <paper-item tabindex="-1">
+            <a href="[[dashboardPath]]lista" class="menu" tabindex="-1">
+              <iron-icon icon="supervisor-account" slot="item-icon"></iron-icon>
+              Contatos
+            </a>
+          </paper-item>
 
+          <paper-item tabindex="-1">
+            <a href="[[dashboardPath]]listagrid" class="menu" tabindex="-1">
+              <iron-icon icon="star" slot="item-icon"></iron-icon>
+              Itens
+            </a>
+          </paper-item>
 
-            <paper-item><a href="[[dashboardPath]]timeline" class="menu"><iron-icon icon="thumb-up" slot="item-icon"></iron-icon> Social <div main-code class="bs-label bg-transparent">22</div></a></paper-item>
+          <paper-item tabindex="-1">
+            <a href="[[dashboardPath]]armacao" class="menu" tabindex="-1">
+              <iron-icon icon="mail" slot="item-icon"></iron-icon>
+              Atendimento
+            </a>
+          </paper-item>
 
-            <paper-item><a href="[[dashboardPath]]timeline" class="menu"><iron-icon icon="social:notifications-active" slot="item-icon"></iron-icon> Alertas <div main-code class="bs-label bg-transparent">22</div></a></paper-item>
--->
-
-
-            <hr class="separated">
-            <p style="padding-left: 1em; margin-bottom: 0;"><small>Menu</small></p>
-            <!--<paper-item><a href="[[dashboardPath]]contatos" class="menu"><iron-icon icon="account-circle" slot="item-icon"></iron-icon> Adicionar Contato</a></paper-item> -->
-            <paper-item><a href="[[dashboardPath]]lista" class="menu"><iron-icon icon="supervisor-account" slot="item-icon"></iron-icon> Contatos</a></paper-item>
-            <paper-item><a href="[[dashboardPath]]listagrid" class="menu"><iron-icon icon="star" slot="item-icon"></iron-icon> Itens</a></paper-item>
-            <paper-item><a href="[[dashboardPath]]armacao" class="menu"><iron-icon icon="mail" slot="item-icon"></iron-icon> Atendimento</a></paper-item>
-
-          <paper-menu >
-            <paper-item on-click="toggle" aria-expanded$="[[opened]]" aria-controls="collapse" class="collapse-menu"><a>Outros <iron-icon icon="arrow-drop-down" slot="item-icon"></iron-icon></a></paper-item>
+          <paper-menu>
+            <paper-item on-click="toggle" aria-expanded$="[[opened]]" aria-controls="collapse" class="collapse-menu" tabindex="-1">
+              <a tabindex="-1">
+                Outros
+                <iron-icon icon="arrow-drop-down" slot="item-icon"></iron-icon>
+              </a>
+            </paper-item>
 
             <iron-collapse id="collapse" opened="{{opened}}">
               <paper-menu class="menu-content">
-
-                <paper-item><a href="[[dashboardPath]]drag" class="menu"><iron-icon icon="extension" slot="item-icon"></iron-icon> Drag</a></paper-item>
-
-                <paper-item><a href="[[dashboardPath]]oculosdegrau" class="menu"><iron-icon icon="label" slot="item-icon"></iron-icon> Oculos de Grau</a></paper-item>
-                <paper-item><a href="[[dashboardPath]]prescricao" class="menu"><iron-icon icon="label" slot="item-icon"></iron-icon> Prescrição</a></paper-item>
-                <paper-item><a href="[[dashboardPath]]armacao" class="menu"><iron-icon icon="label" slot="item-icon"></iron-icon> Armação</a></paper-item>
-                <paper-item><a href="[[dashboardPath]]armacaoform" class="menu"><iron-icon icon="label" slot="item-icon"></iron-icon> Armação Formulário</a></paper-item>
-                <paper-item><a href="[[dashboardPath]]listagrid" class="menu"><iron-icon icon="label" slot="item-icon"></iron-icon> List Grid</a></paper-item>
-
-                <paper-item><a href="[[dashboardPath]]lentes" class="menu"><iron-icon icon="label" slot="item-icon"></iron-icon> Lentes</a></paper-item>
-
-
-
+                <paper-item tabindex="-1">
+                  <a href="[[dashboardPath]]drag" class="menu" tabindex="-1">
+                    <iron-icon icon="extension" slot="item-icon"></iron-icon>
+                    Drag
+                  </a>
+                </paper-item>
+                <paper-item tabindex="-1">
+                  <a href="[[dashboardPath]]oculosdegrau" class="menu" tabindex="-1">
+                    <iron-icon icon="label" slot="item-icon"></iron-icon>
+                    Oculos de Grau
+                  </a>
+                </paper-item>
+                <paper-item tabindex="-1">
+                  <a href="[[dashboardPath]]prescricao" class="menu" tabindex="-1">
+                    <iron-icon icon="label" slot="item-icon"></iron-icon>
+                    Prescrição
+                  </a>
+                </paper-item>
+                <paper-item tabindex="-1">
+                  <a href="[[dashboardPath]]armacao" class="menu" tabindex="-1">
+                    <iron-icon icon="label" slot="item-icon"></iron-icon>
+                    Armação
+                  </a>
+                </paper-item>
+                <paper-item tabindex="-1">
+                  <a href="[[dashboardPath]]armacaoform" class="menu" tabindex="-1">
+                    <iron-icon icon="label" slot="item-icon"></iron-icon>
+                    Armação Formulário
+                  </a>
+                </paper-item>
+                <paper-item tabindex="-1">
+                  <a href="[[dashboardPath]]listagrid" class="menu" tabindex="-1">
+                    <iron-icon icon="label" slot="item-icon"></iron-icon>
+                    List Grid
+                  </a>
+                </paper-item>
+                <paper-item tabindex="-1">
+                  <a href="[[dashboardPath]]lentes" class="menu" tabindex="-1">
+                    <iron-icon icon="label" slot="item-icon"></iron-icon>
+                    Lentes
+                  </a>
+                </paper-item>
+              </paper-menu>
             </iron-collapse>
-          </paper-menu>
 
             <hr class="separated">
-            <paper-item><a href="[[rootPath]]"><iron-icon icon="help" slot="item-icon"></iron-icon> Ajuda</a></paper-item>
-            <paper-item><a href="[[rootPath]]"><iron-icon icon="settings" slot="item-icon"></iron-icon> Configurações</a></paper-item>
-            <paper-item><a href="[[rootPath]]"><iron-icon icon="cached" slot="item-icon"></iron-icon> Sincronizar</a></paper-item>
-              <hr class="separated">
-            <paper-item><a href="[[rootPath]]" class="geek-blue"><iron-icon icon="settings-power" slot="item-icon"></iron-icon> Logout</a></paper-item>
+
+            <paper-item tabindex="-1">
+              <a href="[[rootPath]]" tabindex="-1">
+                <iron-icon icon="help" slot="item-icon"></iron-icon>
+                Ajuda
+              </a>
+            </paper-item>
+            <paper-item tabindex="-1">
+              <a href="[[rootPath]]" tabindex="-1">
+                <iron-icon icon="settings" slot="item-icon"></iron-icon>
+                Configurações
+              </a>
+            </paper-item>
+            <paper-item tabindex="-1">
+              <a href="[[rootPath]]" tabindex="-1">
+                <iron-icon icon="cached" slot="item-icon"></iron-icon>
+                Sincronizar
+              </a>
+            </paper-item>
+            
+            <hr class="separated">
+
+            <paper-item tabindex="-1" tabindex="-1">
+              <a href="[[rootPath]]" class="geek-blue" tabindex="-1">
+                <iron-icon icon="settings-power" slot="item-icon"></iron-icon>
+                Logout
+              </a>
+            </paper-item>
           </paper-menu>
-
         </iron-selector>
-        <p"><small> </small></p>
-        <hr class="separated">
 
+        <hr class="separated">
         <p style="padding: 0 1em;"><small>OptiSoul - Optidados</small></p>
         <p style="padding: 0 1em;">©2018 Geeks Labs, B15</p>
       </div>
-
     </app-drawer>
 
     <section id="view">
-
       <app-route
-             route="{{route}}"
-             pattern="/:page"
-             data="{{routeData}}"></app-route>
-           <iron-pages selected="[[routeData.page]]" attr-for-selected="name" fallback-selection="contatos" selected-attribute="visible" role="main">
-             <contatos-page name="contatos"></contatos-page>
-             <lists-page name="lista"></lists-page>
-             <listsgrid-page name="listagrid"></listsgrid-page>
-             <listsgridinfo-page name="listsgridinfo"></listsgridinfo-page>
-             <drag-page name="drag"></drag-page>
-             <timeline-page name="timeline"></timeline-page>
-             <chat-page name="chat"></chat-page>
-             <itens-page name="itens"></itens-page>
-             <prescricao-page name="prescricao"></prescricao-page>
-             <oculosdegrau-page name="oculosdegrau"></oculosdegrau-page>
-             <armacao-page name="armacao"></armacao-page>
-             <armacaoform-page name="armacaoform"></armacaoform-page>
-             <lentes-page name="lentes"></lentes-page>
-             <vendas-page name="vendas"></vendas-page>
-           </iron-pages>
-
+        route="{{route}}"
+        pattern="/:page"
+        data="{{routeData}}">
+      </app-route>
+      <iron-pages
+        selected="[[routeData.page]]"
+        attr-for-selected="name"
+        fallback-selection="contatos"
+        selected-attribute="visible"
+        role="main">
+        <contatos-page name="contatos"></contatos-page>
+        <lists-page name="lista"></lists-page>
+        <listsgrid-page name="listagrid"></listsgrid-page>
+        <listsgridinfo-page name="listsgridinfo"></listsgridinfo-page>
+        <drag-page name="drag"></drag-page>
+        <timeline-page name="timeline"></timeline-page>
+        <chat-page name="chat"></chat-page>
+        <itens-page name="itens"></itens-page>
+        <prescricao-page name="prescricao"></prescricao-page>
+        <oculosdegrau-page name="oculosdegrau"></oculosdegrau-page>
+        <armacao-page name="armacao"></armacao-page>
+        <armacaoform-page name="armacaoform"></armacaoform-page>
+        <lentes-page name="lentes"></lentes-page>
+        <vendas-page name="vendas"></vendas-page>
+      </iron-pages>
     </section>
+
   </template>
+
   <script src="Dashboard.component.js"></script>
+
 </dom-module>

--- a/src/pages/lists/ListsGrid.component.html
+++ b/src/pages/lists/ListsGrid.component.html
@@ -11,43 +11,41 @@
             <app-toolbar>
                 <paper-icon-button icon="arrow-back"></paper-icon-button>
                 <div spacer main-title class="section-title">Lista de Fotos</div>
+                <paper-input label="Buscar" class="card" no-label-float name="search" on-value-changed="onChangeValueSearch">
+                    <iron-icon icon="search" slot="prefix"></iron-icon>
+                </paper-input>
                 <paper-icon-button icon="file-upload" id="button-import"></paper-icon-button>
                 <paper-tooltip for="button-import" offset="0" position="top">Importar</paper-tooltip>
 
                 <paper-icon-button icon="refresh" id="button-refresh"></paper-icon-button>
                 <paper-tooltip for="button-refresh" offset="0" position="top">Atualizar</paper-tooltip>
-
-
             </app-toolbar>
         </app-header>
-
-
         <div class="page display-table-on-mobile flex-size-12 flex-vertical flex-stretch">
-
             <paper-input label="Buscar" class="card" no-label-float  >
                 <iron-icon icon="search" slot="prefix"></iron-icon>
             </paper-input>
-
-
-            <iron-ajax url="../../armacao.json  " last-response="{{data}}" auto></iron-ajax>
-            <iron-list id="list" items="[[data]]" as="item" selection-enabled grid>
-                <template>
-
+            <iron-ajax
+                url="../../armacao.json"
+                last-response="{{data}}"
+                on-response="handleResponse"
+                auto>
+            </iron-ajax>
+            <div class="list-items">
+                <template is="dom-repeat" items="{{dataList}}">
                     <a href="/dashboard/itens" class="photoContainer">
                         <div class="photoContent" tabindex$="[[tabIndex]]">
-                            <iron-image sizing="cover"
-                                        src="[[item.image]]">
-                            </iron-image>
+                            <iron-image sizing="cover" src="[[item.image]]"></iron-image>
                             <div class="detail">[[item.name]]</div>
                         </div>
                     </a>
                 </template>
-            </iron-list>
-
-
-
+            </div>
         </div>
 
+        <div>
+        </div>
+        
         <paper-fab mini icon="add" id="add"></paper-fab>
         <paper-dialog id="actions" modal>
             <h2>Dialog Title</h2>

--- a/src/pages/lists/ListsGrid.component.js
+++ b/src/pages/lists/ListsGrid.component.js
@@ -13,32 +13,51 @@ class ListsGrid extends Polymer.Element {
             rootPath: String,
             selected: {
                 type: Number,
-                value: 0
+                value: 0,
             },
-            selected2:{
+            selected2: {
                 type: Number,
-                value: 0
-            }
+                value: 0,
+            },
+            dataList: {
+                type: Array,
+                value: [],
+            },
         };
-
     }
+
+    handleResponse({detail}) {
+        const {response} = detail;
+        this.dataList = response;
+    }
+
+    onChangeValueSearch({detail}) {
+        const {value} = detail;
+        const data = this.data;
+
+        const filteredData = data.filter((item) => item.name.toLowerCase().includes(value) && item);
+
+        this.dataList = filteredData;
+    }
+
     colorForItem(item) {
         return item ? (item.status == 0 ? 'blue' : 'red') : '';
     }
+
     iconForItem(item) {
         return item ? (item.status == 0 ? 'check' : 'clear') : '';
     }
 
     ready() {
         super.ready();
-        this.$.add.addEventListener('click', this.golink.bind(this), false);
+        this.$.add.addEventListener('click', this.golink.bind(this), false);   
     }
+
     openBy() {
         this.$.actions.open();
     }
 
     golink(el) {
-        // Wait for ripple to finish.
         location.href = '/dashboard/itens';
     }
 }

--- a/src/pages/lists/ListsGrid.style.html
+++ b/src/pages/lists/ListsGrid.style.html
@@ -91,6 +91,13 @@
                     opacity: 1;
                 }
             }
+
+            .list-items {
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: center;
+                align-items: center;
+            }
         </style>
     </template>
 </dom-module>


### PR DESCRIPTION
- [x] Remover foco dos elementos quando tooggle do menu é ativado
- [x] Fazer search de items dentro da tela de Itens*.

 Alterações:
---
 - remover o `iron-list` e usar `dom-repeat`, a razão pra essa escolha é que o dom-repeat atualiza a lista de itens renderizados a cada filtro.
- usar `onResponse` callback do `iron-ajax` pra definir um valor inicial para os items.

Exemplo:
---
- Para testar o filtro, acessa o link `...:8081/dashboard/listagrid`, modifiquei o `armacao.json` para conseguir filtrar os itens, na barra superior tem o botão de pesquisa onde basta digitar para receber o resultado - o design do botão foi apenas pra exemplo, podendo ser mudado -.
- pode usar como exemplo `item` onde virão apenas os items com `item` dentro do nome.